### PR TITLE
Fix scroll to bottom

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -77,7 +77,7 @@ export default class PreviewKeybinds extends Plugin {
             preview.applyScroll(0);
             break;
          case this.settings.scrollBottom:
-            preview.applyScroll(view.editor.lastLine());
+            preview.applyScroll(view.editor.lastLine() - 40);
             break;
          default:
             return;


### PR DESCRIPTION
For me scrolling to the bottom is not working. Setting the scroll to `view.editor.lastLine() - 40` fixes the issue 🤷  Maybe someone else ran into the same problem